### PR TITLE
Update RSS Viewer description text in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,6 @@
 <body>
     <h1>Tools Directory</h1>
     <p><a href="./font-compare/index.html">Font Comparison Tool</a>: A simple utility to compare two fonts side by side.</p>
-    <p><a href="./rss-viewer/index.html">RSS Viewer</a>: Load an RSS or Atom feed URL and read articles in a floating article window.</p>
+    <p><a href="./rss-viewer/index.html">RSS Viewer</a>: Load an RSS or Atom feed URL and inspect articles, both rendered and source code.</p>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -8,6 +8,6 @@
 <body>
     <h1>Tools Directory</h1>
     <p><a href="./font-compare/index.html">Font Comparison Tool</a>: A simple utility to compare two fonts side by side.</p>
-    <p><a href="./rss-viewer/index.html">RSS Viewer</a>: Load an RSS or Atom feed URL and inspect articles, both rendered and source code.</p>
+    <p><a href="./rss-viewer/index.html">RSS Viewer</a>: View articles from RSS/Atom feeds, with rendered and source code views.</p>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Clarify the RSS Viewer listing to indicate it can show both rendered articles and source code rather than only reading articles in a floating window.

### Description
- Edit `index.html` to replace the sentence describing RSS Viewer with: "Load an RSS or Atom feed URL and inspect articles, both rendered and source code.".

### Testing
- Verified the string replacement in `index.html` using `rg`, served the `tools` directory with `python -m http.server`, and captured a Playwright screenshot of `http://127.0.0.1:4173/index.html`, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4a8d53e08832dac33b417156cad7d)